### PR TITLE
Ensures s3_paths always has at least one item

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.jinja
+++ b/main.jinja
@@ -15,7 +15,7 @@ locals {
 
   uri_map  = "${merge(var.uri_map, local.source_s3_uri_map)}"
   uris     = "${keys(local.uri_map)}"
-  s3_paths = "${values(local.uri_map)}"
+  s3_paths = "${concat(values(local.uri_map), list("NULL"))}"
 }
 
 data "template_file" "bucket_policy" {


### PR DESCRIPTION
s3_paths is only used if there are URIs in uri_map. If a user is
passing an empty uri_map and an empty s3_object_map, then there
are no URIs to retrieve. This works _conceptually_ because the
`count` that utilizes s3_paths would be zero in this scenario,
and terraform would never actually index into the empty s3_paths
list.

However, it turns out that locals evaluate super early, so terraform
still tries to index into the empty list, which fails.

This patch ensures there is always an item in the list, and it is
always the last item. When the uri_map is empty, the local evaluation
is happy, and things work because there are no URIs to retrieve
anyway.

When URIs are being retrieved, the count is derived from the length
of the uri_map, and so stops before getting to the dummy list item.

:facepalm: