### PR TITLE
Supports cli and env vars, using same precedence as terraform

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.1.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ pip install requirements.txt
 Then render the files:
 
 ```
-python render.py -var-file <var-file1> -var-file <var-file2> ... -var-file <var-fileN>
+python render.py -var-file <var-file1> -var <var1="val1"> ... -var-file <var-fileN>
 ```
 
-Once rendered, run terraform as usual, passing the same var-file(s):
+Once rendered, run terraform as usual, passing the same vars/var-file(s):
 
 ```
 terraform init
-terraform apply -var-file <var-file1> -var-file <var-file2> ... -var-file <var-fileN>
+terraform apply -var-file <var-file1> -var <var1="val1"> ... -var-file <var-fileN>
 ```
 
 We recommend using Terragrunt and [Terragrunt hooks][terragrunt-hooks], in

--- a/main.jinja
+++ b/main.jinja
@@ -47,7 +47,7 @@ locals {
 }
 
 module "file_cache" {
-  source = "git::https://github.com/plus3it/terraform-external-file-cache?ref=1.2.0"
+  source = "git::https://github.com/plus3it/terraform-external-file-cache?ref=1.2.1"
 
   uris = "${local.uris}"
 }

--- a/render.py
+++ b/render.py
@@ -85,7 +85,10 @@ def load_variables(var_objects):
         with open(terrafile) as fh:
             data = hcl.load(fh)
             for key, value in data.get("variable", {}).items():
-                if "default" in value:
+                env_key = '{0}{1}'.format('TF_VAR_', key)
+                if env_key in os.environ:
+                    variables.update({key: os.environ[env_key]})
+                elif "default" in value:
                     variables.update({key: value["default"]})
 
     for var in var_objects:


### PR DESCRIPTION
Terraform evaluates variables from multiple sources: defaults, env, and command line. The order of precedence is:

* cli (-var and -var-file), later vars on the cli override earlier vars of the same name
* env (TF_VAR_<var_name>)
* default value

This patch adds support for -var cli and env variables, and applies the same order of precedence as terraform.