### PR TITLE
Ensures resource IDs represent the object being *created*

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 3.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/tests/uri_map/main.tf
+++ b/tests/uri_map/main.tf
@@ -2,14 +2,17 @@ terraform {
   required_version = ">= 0.12"
 }
 
-resource "aws_s3_bucket" "this" {
-  bucket_prefix = "terraform-aws-wrangler-"
+data "terraform_remote_state" "prereq" {
+  backend = "local"
+  config = {
+    path = "prereq/terraform.tfstate"
+  }
 }
 
 module "uri_map" {
   source = "../../"
 
-  bucket_name = aws_s3_bucket.this.id
+  bucket_name = data.terraform_remote_state.prereq.outputs.bucket.id
   prefix      = local.prefix
   uri_map     = local.uri_map
 }

--- a/tests/uri_map/prereq/main.tf
+++ b/tests/uri_map/prereq/main.tf
@@ -1,0 +1,11 @@
+provider aws {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket_prefix = "terraform-aws-wrangler-"
+}
+
+output "bucket" {
+  value = aws_s3_bucket.this
+}


### PR DESCRIPTION
Previously, the resource ID was the object source, and so objects
would be recreated if the source changed. I.e. if the object were
retrieved from a different source URI, but still written to the
same destination, then the object would be destroyed and recreated
even if the objects contents remained the same. That would lead to
a race condition on the destroy/create cycle.